### PR TITLE
Handle sign in errors

### DIFF
--- a/lib/features/auth/data/auth_service.dart
+++ b/lib/features/auth/data/auth_service.dart
@@ -2,18 +2,37 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../models/app_user.dart';
 
+class AuthException implements Exception {
+  final String message;
+  AuthException(this.message);
+
+  @override
+  String toString() => message;
+}
+
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _db = FirebaseFirestore.instance;
 
   Future<AppUser?> signIn(String email, String password) async {
-    final credential = await _auth.signInWithEmailAndPassword(
-      email: email,
-      password: password,
-    );
-    final user = credential.user;
-    if (user == null) return null;
-    final doc = await _db.collection('users').doc(user.uid).get();
-    return AppUser.fromMap(user.uid, doc.data() ?? {});
+    try {
+      final credential = await _auth.signInWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      final user = credential.user;
+      if (user == null) return null;
+      final doc = await _db.collection('users').doc(user.uid).get();
+      return AppUser.fromMap(user.uid, doc.data() ?? {});
+    } on FirebaseAuthException catch (e) {
+      switch (e.code) {
+        case 'user-not-found':
+          throw AuthException('No user found for that email.');
+        case 'wrong-password':
+          throw AuthException('Incorrect password.');
+        default:
+          throw AuthException(e.message ?? 'Authentication failed.');
+      }
+    }
   }
 }

--- a/lib/features/auth/presentation/login_page.dart
+++ b/lib/features/auth/presentation/login_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import '../data/auth_service.dart';
 
 import '../../../core/router.dart';
@@ -47,9 +46,12 @@ class _LoginPageState extends State<LoginPage> {
             Navigator.pushReplacementNamed(context, "/resident");
         }
       }
-    } catch (e) {
+    } on AuthException catch (e) {
       ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(e.toString())));
+          .showSnackBar(SnackBar(content: Text(e.message)));
+    } catch (_) {
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('An unexpected error occurred.')));
     } finally {
       if (mounted) setState(() => _loading = false);
     }


### PR DESCRIPTION
## Summary
- surface friendly sign-in failures from Firebase
- show error messages on login screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e0c155afc8328af458c4e016d647f