### PR TITLE
Add request submission screen

### DIFF
--- a/lib/features/home/presentation/resident_home.dart
+++ b/lib/features/home/presentation/resident_home.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../../requests/presentation/requests_page.dart';
+import '../../requests/presentation/add_request_page.dart';
 import '../../notifications/presentation/notifications_page.dart';
 import '../../settings/presentation/settings_page.dart';
 
@@ -16,7 +16,7 @@ class ResidentHome extends StatelessWidget {
             title: const Text('Create Request'),
             onTap: () => Navigator.push(
               context,
-              MaterialPageRoute(builder: (_) => const RequestsPage(role: 'resident')),
+              MaterialPageRoute(builder: (_) => const AddRequestPage()),
             ),
           ),
           ListTile(

--- a/lib/features/requests/presentation/add_request_page.dart
+++ b/lib/features/requests/presentation/add_request_page.dart
@@ -1,0 +1,144 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:image_picker/image_picker.dart';
+
+class AddRequestPage extends StatefulWidget {
+  const AddRequestPage({Key? key}) : super(key: key);
+
+  @override
+  State<AddRequestPage> createState() => _AddRequestPageState();
+}
+
+class _AddRequestPageState extends State<AddRequestPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _zhkController = TextEditingController();
+  final _locationTypeController = TextEditingController();
+  final _roomController = TextEditingController();
+  final _categoryController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  final ImagePicker _picker = ImagePicker();
+  File? _image;
+  bool _loading = false;
+
+  Future<void> _pickImage() async {
+    final picked = await _picker.pickImage(source: ImageSource.gallery);
+    if (picked != null) {
+      setState(() {
+        _image = File(picked.path);
+      });
+    }
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _loading = true);
+    String? photoUrl;
+    try {
+      if (_image != null) {
+        final ref = FirebaseStorage.instance
+            .ref()
+            .child('requests/${DateTime.now().millisecondsSinceEpoch}.jpg');
+        await ref.putFile(_image!);
+        photoUrl = await ref.getDownloadURL();
+      }
+      await FirebaseFirestore.instance.collection('requests').add({
+        'zhk': _zhkController.text.trim(),
+        'locationType': _locationTypeController.text.trim(),
+        'roomNumber': _roomController.text.trim(),
+        'category': _categoryController.text.trim(),
+        'description': _descriptionController.text.trim(),
+        'photoUrl': photoUrl,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+      if (mounted) Navigator.pop(context);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(e.toString())));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _zhkController.dispose();
+    _locationTypeController.dispose();
+    _roomController.dispose();
+    _categoryController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('New Request')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: _zhkController,
+                decoration: const InputDecoration(labelText: 'ЖК'),
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _locationTypeController,
+                decoration: const InputDecoration(labelText: 'Location Type'),
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _roomController,
+                decoration: const InputDecoration(labelText: 'Room Number'),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _categoryController,
+                decoration: const InputDecoration(labelText: 'Category'),
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(labelText: 'Description'),
+                maxLines: 3,
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextButton.icon(
+                onPressed: _pickImage,
+                icon: const Icon(Icons.photo),
+                label: const Text('Upload Photo'),
+              ),
+              if (_image != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Image.file(_image!, height: 150),
+                ),
+              const SizedBox(height: 24),
+              _loading
+                  ? const Center(child: CircularProgressIndicator())
+                  : SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: _submit,
+                        child: const Text('Submit'),
+                      ),
+                    ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   cloud_firestore: ^4.7.0
   firebase_storage: ^11.1.0
   provider: ^6.0.5
+  image_picker: ^0.8.7+5
   flutter_localizations:
     sdk: flutter
 


### PR DESCRIPTION
## Summary
- add a form for creating requests
- allow photo upload and store it in Firebase Storage
- write new documents to Firestore
- route Resident home to the new screen
- include image_picker in pubspec

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e435417908328a3fa04ec8bc685c9