### PR TITLE
Implement startup auth flow

### DIFF
--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import '../features/auth/presentation/login_page.dart';
+import '../features/auth/presentation/startup_page.dart';
 import '../features/home/presentation/admin_home.dart';
 import '../features/home/presentation/staff_home.dart';
 import '../features/home/presentation/resident_home.dart';
 
 class AppRouter {
-  static const String initial = '/login';
+  static const String initial = '/startup';
 
   static Route<dynamic> generateRoute(RouteSettings settings) {
     switch (settings.name) {
+      case '/startup':
+        return MaterialPageRoute(builder: (_) => const StartupPage());
       case '/login':
         return MaterialPageRoute(builder: (_) => const LoginPage());
       case '/admin':

--- a/lib/features/auth/data/auth_service.dart
+++ b/lib/features/auth/data/auth_service.dart
@@ -6,6 +6,30 @@ class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _db = FirebaseFirestore.instance;
 
+  Future<AppUser?> currentUser() async {
+    final user = _auth.currentUser;
+    if (user == null) return null;
+    final doc = await _db.collection('users').doc(user.uid).get();
+    if (!doc.exists) return null;
+    return AppUser.fromMap(user.uid, doc.data()!);
+  }
+
+  Future<AppUser?> registerResident(
+      String email, String password, String zhksId) async {
+    final credential = await _auth.createUserWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+    final user = credential.user;
+    if (user == null) return null;
+    await _db.collection('users').doc(user.uid).set({
+      'email': email,
+      'role': 'resident',
+      'zhksId': zhksId,
+    });
+    return AppUser(id: user.uid, email: email, role: 'resident', zhksId: zhksId);
+  }
+
   Future<AppUser?> signIn(String email, String password) async {
     final credential = await _auth.signInWithEmailAndPassword(
       email: email,

--- a/lib/features/auth/presentation/startup_page.dart
+++ b/lib/features/auth/presentation/startup_page.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import '../data/auth_service.dart';
+
+class StartupPage extends StatefulWidget {
+  const StartupPage({Key? key}) : super(key: key);
+
+  @override
+  State<StartupPage> createState() => _StartupPageState();
+}
+
+class _StartupPageState extends State<StartupPage> {
+  final AuthService _authService = AuthService();
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    final user = await _authService.currentUser();
+    if (!mounted) return;
+    if (user == null) {
+      Navigator.pushReplacementNamed(context, '/login');
+    } else {
+      switch (user.role) {
+        case 'admin':
+          Navigator.pushReplacementNamed(context, '/admin');
+          break;
+        case 'staff':
+          Navigator.pushReplacementNamed(context, '/staff');
+          break;
+        default:
+          Navigator.pushReplacementNamed(context, '/resident');
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: CircularProgressIndicator()),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add user registration and current user helpers
- create StartupPage
- route to StartupPage initially

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e4358c9548328bbf6b395d4abb07a